### PR TITLE
Support Webdriver custom options by kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Add something like this in your scrapy project settings:
     }
 
     WEBDRIVER_BROWSER = 'PhantomJS'  # Or any other from selenium.webdriver
+    # Optional passing of parameters to the webdriver
+    WEBDRIVER_OPTIONS = {
+        'service_args': ['--debug=true', '--load-images=false', '--webdriver-loglevel=debug']
+    }
 
 Usage
 =====

--- a/scrapy_webdriver/manager.py
+++ b/scrapy_webdriver/manager.py
@@ -17,6 +17,8 @@ class WebdriverManager(object):
         self._wait_inpage_queue = deque()
         self._browser = crawler.settings.get('WEBDRIVER_BROWSER', None)
         self._user_agent = crawler.settings.get('USER_AGENT', None)
+        self._web_driver_options = crawler.settings.get('WEBDRIVER_OPTIONS',
+                                                        dict())
         self._webdriver = None
         if isinstance(self._browser, basestring):
             self._browser = getattr(webdriver, self._browser)
@@ -42,7 +44,8 @@ class WebdriverManager(object):
     def webdriver(self):
         """Return the webdriver instance, instantiate it if necessary."""
         if self._webdriver is None:
-            options = dict(desired_capabilities=self._desired_capabilities)
+            options = self._web_driver_options
+            options['desired_capabilities'] = self._desired_capabilities
             self._webdriver = self._browser(**options)
             self.crawler.signals.connect(self._cleanup, signal=engine_stopped)
         return self._webdriver


### PR DESCRIPTION
Can you run the tests and see if it breaks anything, seems there is some problem with running tests on my pc.

This is the error I see when I run tests:

```
platform linux2 -- Python 2.7.4 -- pytest-2.3.5
collected 1 items / 1 errors 

scrapy_webdriver/tests/test_request_queue.py .

=========================================================== ERRORS ============================================================
___________________________ ERROR collecting build/lib/scrapy_webdriver/tests/test_request_queue.py ___________________________
import file mismatch:
imported module 'scrapy_webdriver.tests.test_request_queue' has this __file__ attribute:
  /home/samos/workspace/scrapy-webdriver/scrapy_webdriver/tests/test_request_queue.py
which is not the same as the test file we want to collect:
  /home/samos/workspace/scrapy-webdriver/build/lib/scrapy_webdriver/tests/test_request_queue.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
============================================= 1 passed, 1 error in 93.28 seconds ===========
```
